### PR TITLE
Feat: 소셜 로그인 과정에 필요한 화면 구현 및 API 통신 로직 구현(이메일 인증, 인증번호 처리 API 통신은 아직)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,7 @@
     "react/function-component-definition": [
       2,
       { "namedComponents": ["arrow-function", "function-declaration"] }
-    ]
+    ],
+    "arrow-body-style": "off" // 화살표 함수 내부에서 중괄호와 return 사용 허용
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0",
     "react-scripts": "5.0.1",
+    "react-toastify": "^10.0.6",
     "styled-components": "^6.1.13",
     "web-vitals": "^2.1.0"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,7 @@
 import './App.css';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import GlobalStyle from './styles/GlobalStyle';
 import HomePage from './pages/HomePage';
 import RecipePage from './pages/RecipePage';
@@ -10,10 +12,13 @@ import SearchPage from './pages/SearchPage';
 import NotFoundPage from './pages/NotFoundPage';
 import LoginPage from './pages/LoginPage';
 import PreLoginPage from './pages/PreLoginPage';
+import OAuthVerification from './pages/OAuthVerification';
+import { AuthProvider } from './context/Auth/AuthProvider';
 
 function App() {
   return (
     <Router>
+      <ToastContainer />
       <GlobalStyle /> {/* 전역 스타일 적용 */}
       <Routes>
         <Route path="/" element={<PreLoginPage />} />
@@ -24,6 +29,14 @@ function App() {
         <Route path="/favorite" element={<FavoritePage />} />
         <Route path="/my" element={<MyPage />} />
         <Route path="/search" element={<SearchPage />} />
+        <Route
+          path="/oauth/:provider"
+          element={
+            <AuthProvider>
+              <OAuthVerification />
+            </AuthProvider>
+          }
+        />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </Router>

--- a/src/components/EmailVerification.jsx
+++ b/src/components/EmailVerification.jsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { CheckCircleOutline, ErrorOutline } from '@mui/icons-material';
+import AuthApi from '../services/auth.api';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  padding: 0 20px;
+  background-color: #f9f9f9;
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 400px;
+`;
+
+const Input = styled.input`
+  padding: 10px;
+  margin: 10px 0;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+  font-size: 16px;
+  outline: none;
+`;
+
+const Button = styled.button`
+  padding: 12px;
+  background-color: #4caf50;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  font-size: 16px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+
+  &:disabled {
+    background-color: #ccc;
+  }
+
+  &:hover {
+    background-color: ${(props) => (props.disabled ? '#ccc' : '#45a049')};
+  }
+`;
+
+const Message = styled.p`
+  margin-top: 15px;
+  font-size: 14px;
+  color: ${(props) => (props.error ? 'red' : 'green')};
+  display: flex;
+  align-items: center;
+
+  svg {
+    margin-right: 5px;
+  }
+`;
+
+const EmailVerification = ({ onSend }) => {
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  const handleSendVerification = async (e) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setMessage('');
+
+    // 이메일 전송 처리
+    onSend(email); // 이메일 발송 함수 호출
+    setMessage('인증 코드가 이메일로 발송되었습니다.'); // 상태 업데이트
+    setIsLoading(false);
+  };
+
+  return (
+    <Container>
+      <h2>이메일 인증</h2>
+      <Form onSubmit={handleSendVerification}>
+        <Input
+          type="email"
+          placeholder="이메일을 입력하세요"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <Button type="submit" disabled={isLoading}>
+          {isLoading ? '전송 중...' : '인증 메일 발송'}
+        </Button>
+      </Form>
+      {message && (
+        <Message error={isError}>
+          {isError ? <ErrorOutline /> : <CheckCircleOutline />}
+          {message}
+        </Message>
+      )}
+    </Container>
+  );
+};
+
+export default EmailVerification;

--- a/src/components/VerificationCodeInput .jsx
+++ b/src/components/VerificationCodeInput .jsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+
+// Styled Components
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  padding: 0 20px;
+  background-color: #f9f9f9;
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 400px;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  padding: 20px;
+`;
+
+const Title = styled.h2`
+  font-size: 20px;
+  text-align: center;
+  margin-bottom: 20px;
+`;
+
+const Input = styled.input`
+  padding: 12px;
+  margin: 10px 0;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+  font-size: 16px;
+  outline: none;
+
+  &:focus {
+    border-color: #4caf50;
+  }
+`;
+
+const Button = styled.button`
+  padding: 12px;
+  background-color: #4caf50;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  font-size: 16px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+
+  &:disabled {
+    background-color: #ccc;
+  }
+
+  &:hover {
+    background-color: ${(props) => (props.disabled ? '#ccc' : '#45a049')};
+  }
+`;
+
+const Message = styled.p`
+  margin-top: 15px;
+  font-size: 14px;
+  color: red;
+`;
+
+const VerificationCodeInput = ({ onVerify }) => {
+  const [verificationCode, setVerificationCode] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleVerification = (e) => {
+    e.preventDefault();
+    onVerify(verificationCode); // 인증 코드 확인 함수 호출
+  };
+
+  return (
+    <Container>
+      <Form onSubmit={handleVerification}>
+        <Title>인증 코드를 입력해주세요</Title>
+        <Input
+          type="text"
+          placeholder="인증 코드"
+          value={verificationCode}
+          onChange={(e) => setVerificationCode(e.target.value)}
+          required
+        />
+        <Button type="submit">인증 코드 확인</Button>
+      </Form>
+      {message && <Message>{message}</Message>}
+    </Container>
+  );
+};
+
+export default VerificationCodeInput;

--- a/src/context/Auth/AuthContext.js
+++ b/src/context/Auth/AuthContext.js
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+
+// Context 생성
+export const AuthContext = createContext();
+
+// AuthContext 에 대한 커스텀 훅
+export const useAuth = () => useContext(AuthContext);

--- a/src/context/Auth/AuthProvider.js
+++ b/src/context/Auth/AuthProvider.js
@@ -1,0 +1,44 @@
+import { useReducer, useMemo } from 'react';
+import { AuthContext } from './AuthContext';
+
+// 초기 상태
+const initialState = {
+  user: null,
+  isAuthenticated: false,
+};
+
+// Reducer 함수
+const authReducer = (state, action) => {
+  switch (action.type) {
+    case 'LOGIN':
+      return {
+        ...state,
+        user: action.payload,
+        isAuthenticated: true,
+      };
+    case 'SET_AUTH_DATA':
+      return {
+        ...state,
+        user: action.payload, // ableToLogin이 false인 경우의 사용자 데이터 저장
+        isAuthenticated: false,
+      };
+    case 'LOGOUT':
+      return {
+        ...state,
+        user: null,
+        isAuthenticated: false,
+      };
+    default:
+      return state;
+  }
+};
+
+// Provider 생성
+export const AuthProvider = ({ children }) => {
+  const [state, dispatch] = useReducer(authReducer, initialState);
+
+  // useMemo를 사용하여 value를 메모이제이션
+  const value = useMemo(() => ({ state, dispatch }), [state, dispatch]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,7 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+root.render(<App />);
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -4,32 +4,61 @@ import GoogleIcon from '@mui/icons-material/Google'; // 구글 아이콘
 import { Button } from '@mui/material';
 import { Link } from 'react-router-dom';
 import startScreenImage from '../assets/images/start_screen_img.png';
+import AuthApi from '../services/auth.api';
 
-const LoginPage = () => (
-  <LoginContainer>
-    <Image src={startScreenImage} alt="Welcome" />
-    <Title>CostCook</Title>
-    <ButtonContainer>
-      <LoginButton
-        variant="contained"
-        sx={{ backgroundColor: '#FEE500', color: '#222' }}
-        startIcon={<AccountCircleIcon />}
-      >
-        카카오로 로그인
-      </LoginButton>
-      <LoginButton
-        variant="contained"
-        color="secondary"
-        startIcon={<GoogleIcon />}
-      >
-        구글로 로그인
-      </LoginButton>
-      <SkipButton variant="text">
-        <Link to="/home">건너뛰기</Link>
-      </SkipButton>
-    </ButtonContainer>
-  </LoginContainer>
-);
+const LoginPage = () => {
+  const handleGoogleLogin = () => {
+    // 구글 로그인 버튼 클릭 시 이동하는 경로 지정
+    const params = new URLSearchParams({
+      scope: 'email profile',
+      response_type: 'code',
+      redirect_uri: process.env.REACT_APP_GOOGLE_REDIRECT_URI,
+      client_id: process.env.REACT_APP_GOOGLE_CLIENT_ID,
+    });
+    const GOOGLE_URL = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+    window.location.href = GOOGLE_URL; // 구글 OAuth 로그인 페이지로 이동
+  };
+
+  const handleKakaoLogin = () => {
+    // 카카오 로그인 버튼 클릭 시 이동하는 경로 지정
+    const params = new URLSearchParams({
+      response_type: 'code',
+      redirect_uri: process.env.REACT_APP_KAKAO_REDIRECT_URI,
+      client_id: process.env.REACT_APP_KAKAO_CLIENT_ID,
+    });
+    const KAKAO_URL = `https://kauth.kakao.com/oauth/authorize?${params.toString()}`;
+
+    window.location.href = KAKAO_URL; // 카카오 OAuth 로그인 페이지로 이동
+  };
+
+  return (
+    <LoginContainer>
+      <Image src={startScreenImage} alt="Welcome" />
+      <Title>CostCook</Title>
+      <ButtonContainer>
+        <LoginButton
+          variant="contained"
+          sx={{ backgroundColor: '#FEE500', color: '#222' }}
+          startIcon={<AccountCircleIcon />}
+          onClick={handleKakaoLogin}
+        >
+          카카오로 로그인
+        </LoginButton>
+        <LoginButton
+          variant="contained"
+          color="secondary"
+          startIcon={<GoogleIcon />}
+          onClick={handleGoogleLogin}
+        >
+          구글로 로그인
+        </LoginButton>
+        <SkipButton variant="text">
+          <Link to="/home">건너뛰기</Link>
+        </SkipButton>
+      </ButtonContainer>
+    </LoginContainer>
+  );
+};
 
 export default LoginPage;
 

--- a/src/pages/OAuthVerification.jsx
+++ b/src/pages/OAuthVerification.jsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import AuthApi from '../services/auth.api';
+import { useAuth } from '../context/Auth/AuthContext';
+import EmailVerification from '../components/EmailVerification';
+import VerificationCodeInput from '../components/VerificationCodeInput ';
+
+const OAuthVerification = () => {
+  const { provider } = useParams();
+  const code = new URLSearchParams(window.location.search).get('code');
+  const { state, dispatch } = useAuth(); // state와 dispatch 가져오기
+  const [loading, setLoading] = useState(true); // API 요청 상태 관리
+  const [emailSent, setEmailSent] = useState(false);
+  const [verificationCode, setVerificationCode] = useState('');
+  const [generatedCode, setGeneratedCode] = useState('');
+
+  const generateRandomCode = () => {
+    return Math.floor(100000 + Math.random() * 900000).toString(); // 6자리 랜덤 숫자 생성
+  };
+
+  const handleSendVerificationEmail = (email) => {
+    const randCode = generateRandomCode(); // 랜덤 코드 생성
+    setGeneratedCode(randCode); // 코드 상태에 저장
+    setEmailSent(true); // 이메일 발송 완료 상태 변경
+    console.log(`인증 코드 ${randCode}가 ${email}로 발송되었습니다.`); // 로그에 코드 출력
+    toast.success(`인증 코드 ${code}가 ${email}로 발송되었습니다.`); // 성공 메시지
+  };
+
+  const handleVerifyCode = (inputCode) => {
+    if (inputCode === generatedCode) {
+      toast.success('인증 코드가 확인되었습니다. 회원가입이 완료되었습니다.'); // 인증 완료 메시지
+      setTimeout(async () => {
+        dispatch({
+          type: 'LOGIN',
+          payload: {
+            email: state.user.email,
+            provider: provider.toLowerCase(),
+          },
+        });
+        toast.info('로그인 중입니다...'); // 로그인 중 메시지
+        // 로그인 성공 후 홈으로 이동
+        window.location.href = '/home';
+      }, 2000);
+    } else {
+      toast.error('인증 코드가 올바르지 않습니다. 다시 시도해 주세요.'); // 오류 메시지
+    }
+  };
+
+  const signUpOrLogin = async () => {
+    try {
+      // 1. Provider 로부터 사용자 정보({key, email, name, provider}) 추출한다.
+      // 추출된 사용자 정보에서 provider가 "kakao"일 때 email이 null인 경우에만 ableToLogin: false
+      const res = await AuthApi.getProviderInfo(provider, code);
+
+      // res.data.ableToLogin 이 true 이면, 이메일 인증 과정을 거치지 않고 자동 회원가입 처리 및 로그인 요청을 보낸다.
+      if (res.ableToLogin) {
+        const loginRes = await AuthApi.signUpOrLogin({
+          ...res,
+          provider: res.provider.toLowerCase(),
+        });
+
+        // 로그인 성공하면 전역 상태에 로그인된 사용자 정보를 저장
+        dispatch({
+          type: 'LOGIN',
+          payload: loginRes.data,
+        });
+
+        // 로그인 성공 후 홈으로 리다이렉트
+        window.location.href = '/home';
+      } else {
+        // ableToLogin이 false인 경우 전역 상태에 사용자 정보 저장
+        dispatch({
+          type: 'SET_AUTH_DATA',
+          payload: res, // 이메일 인증 절차를 위해 필요한 데이터 저장
+        });
+      }
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setLoading(false); // API 요청이 완료되면 로딩 상태 해제
+    }
+  };
+
+  useEffect(() => {
+    signUpOrLogin();
+  }, []);
+
+  // 로딩 중인 경우
+  if (loading) {
+    return (
+      <h1>
+        {provider}
+        {provider} 로그인 진행 중...
+      </h1>
+    );
+  }
+
+  // 이메일 인증이 필요한 경우 이메일 인증 폼을 렌더링
+  if (state.user && !state.user.ableToLogin) {
+    return (
+      <div>
+        {!emailSent ? (
+          <EmailVerification onSend={handleSendVerificationEmail} />
+        ) : (
+          <VerificationCodeInput onVerify={handleVerifyCode} />
+        )}
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export default OAuthVerification;

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,39 @@
+import axios from 'axios';
+
+// Axios 인스턴스 생성
+const apiClient = axios.create({
+  baseURL: 'http://localhost:8080/api', // 백엔드 API 기본 URL
+  withCredentials: true, // 쿠키를 포함해서 요청을 보내도록 설정
+});
+
+// 요청 인터셉터 설정 (선택적)
+apiClient.interceptors.request.use(
+  (config) => {
+    // 요청 전 처리가 필요한 경우
+    const token = localStorage.getItem('token'); // 예시로 토큰을 localStorage에서 가져옴
+    // if (token) {
+    //   config.headers.Authorization = `Bearer ${token}`;
+    // }
+    return config;
+  },
+  (error) => {
+    // 요청 에러 처리
+    return Promise.reject(error);
+  }
+);
+
+// 응답 인터셉터 설정 (선택적)
+apiClient.interceptors.response.use(
+  (response) => {
+    // const refreshToken = getCookie('refreshToken');
+    // console.log(refreshToken);
+    return response.data; // 응답의 데이터를 반환
+  },
+  (error) => {
+    // 응답 에러 처리
+    console.error('응답 에러:', error);
+    return Promise.reject(error);
+  }
+);
+
+export default apiClient; // apiClient를 기본 내보내기

--- a/src/services/auth.api.js
+++ b/src/services/auth.api.js
@@ -1,0 +1,18 @@
+import apiClient from './api'; // apiClient를 임포트
+
+// AuthApi 객체
+const AuthApi = {
+  // OAuth 인증 코드로 사용자 정보 요청
+  getProviderInfo: (provider, code) =>
+    apiClient.get(`/oauth/${provider}?code=${code}`), // 사용자 정보 요청
+  // 회원가입 및 로그인 처리
+  signUpOrLogin: (data) => apiClient.post(`/auth/signup-or-login`, data),
+  // 로그아웃 요청 (선택적)
+  logout: async () => {
+    return apiClient.post('/auth/logout'); // 로그아웃 요청
+  },
+  sendVerificationEmail: (data) =>
+    apiClient.post('/auth/send-verification-code', data),
+};
+
+export default AuthApi; // AuthApi 객체를 기본 내보내기

--- a/yarn.lock
+++ b/yarn.lock
@@ -3456,7 +3456,7 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
-clsx@^2.1.1:
+clsx@^2.1.0, clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
@@ -8310,6 +8310,13 @@ react-scripts@5.0.1:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
+
+react-toastify@^10.0.6:
+  version "10.0.6"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-10.0.6.tgz#19c364b1150f495522c738d592d1dcc93879ade1"
+  integrity sha512-yYjp+omCDf9lhZcrZHKbSq7YMuK0zcYkDFTzfRFgTXkTFHZ1ToxwAonzA4JI5CxA91JpjFLmwEsZEgfYfOqI1A==
+  dependencies:
+    clsx "^2.1.0"
 
 react-transition-group@^4.4.5:
   version "4.4.5"


### PR DESCRIPTION
### 작업 내용 (What)
- useContext, useReducer 훅 사용해서 로그인한 사용자 정보 전역 상태 관리
- 이메일 인증 화면 구현
- 인증번호 입력 화면 구현
- 카카오 로그인 버튼 > 카카오 로그인 API 연동
- 구글 로그인 버튼 > 구글 로그인 API 연동
- 인증번호가 담긴 메일 발송 기능 및 인증번호 비교 기능 Fake API 적용
- axios 재사용 가능하도록 커스텀 설정

### 변경 사항 (Changes)
- [x] 로그인한 사용자 정보를 전역 상태로 관리하도록 useContext 훅 사용
- [x] Provider 로부터 제공받은 사용자 정보 state 저장할 수 있도록  useReducer 훅 사용
- [x] 회원가입 후 로그인한 사용자 정보 state 저장할 수 있도록 useReducer 훅 사용
- [x] 공통 사용 가능한 axios 클라이언트 기본 설정
- [x] Auth 에 대한 api 호출 함수 객체화
- [x] 이메일 인증 화면 구현
- [x] 인증번호 입력 화면 구현
- [x] 구글 로그인 및 카카오 로그인 API 연동
- [x] 소셜 로그인 과정 테스트 가능하도록 화면 간 연결