### PR TITLE
Feat: 액세스 토큰 재발급 API 연동 및 axios 인터셉터 설정, 내 정보 조회 API 연동 테스트 화면 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,7 @@
     ],
     "jsx-a11y/label-has-associated-control": "off", // label 오류 비활성화
     "arrow-body-style": "off", // 화살표 함수의 블록 사용 허용
-    "no-return-assign": "off" // return 안에서의 할당 허용
+    "no-return-assign": "off", // return 안에서의 할당 허용
+    "no-underscore-dangle": "off"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
-
+.vscode
 # dependencies
 /node_modules
 /.pnp

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "moment": "^2.30.1",
     "react": "^18.3.1",
     "react-calendar": "^5.0.0",
+    "react-cookie": "^7.2.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0",
     "react-scripts": "5.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import './App.css';
 import {
   BrowserRouter as Router,
@@ -26,13 +27,16 @@ import AdminRecipePage from './pages/admin/RecipePage';
 import AdminIngredientPage from './pages/admin/IngredientPage';
 import PageTransition from './components/common/PageTransition';
 import RecipeIngredientPage from './pages/admin/RecipeIngredientPage';
+import { useAuth } from './context/Auth/AuthContext';
+import UserInfo from './pages/UserInfo';
 
 function App() {
   const location = useLocation();
-
   return (
-    <>
-      <ToastContainer />
+    <AuthProvider>
+      <ToastContainer
+        position="bottom-center" // 위치 설정
+      />
       <GlobalStyle /> {/* 전역 스타일 적용 */}
       <AnimatePresence mode="wait">
         <Routes location={location} key={location.pathname}>
@@ -116,24 +120,18 @@ function App() {
               </PageTransition>
             }
           />
-          <Route
-            path="/oauth/:provider"
-            element={
-              <AuthProvider>
-                <OAuthVerification />
-              </AuthProvider>
-            }
-          />
+          <Route path="/oauth/:provider" element={<OAuthVerification />} />
           <Route path="/admin/ingredient" element={<AdminIngredientPage />} />
           <Route path="/admin/recipe" element={<AdminRecipePage />} />
           <Route
             path="/admin/recipeIngredient"
             element={<RecipeIngredientPage />}
           />
+          <Route path="/users/me" element={<UserInfo />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </AnimatePresence>
-    </>
+    </AuthProvider>
   );
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,16 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import { BrowserRouter } from 'react-router-dom';
+import { CookiesProvider } from 'react-cookie';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <BrowserRouter>
-    <App />
+    <CookiesProvider>
+      <App />
+    </CookiesProvider>
   </BrowserRouter>
 );
 

--- a/src/pages/OAuthVerification.jsx
+++ b/src/pages/OAuthVerification.jsx
@@ -102,6 +102,7 @@ const OAuthVerification = () => {
     }
   };
 
+  // 사용자 정보 추출 -> 로그인 가능하면 로그인 즉시 처리
   const confirmUserLogin = async () => {
     try {
       // 1. Provider 로부터 사용자 정보({key, email, name, provider}) 추출한다.
@@ -126,9 +127,8 @@ const OAuthVerification = () => {
 
         navigate('/home');
         // 로그인 중 메시지 표시 후 500ms 대기 (필요에 따라 조정 가능)
-        setTimeout(() => {
-          // window.location.href = '/home';
-        }, 500); // 500ms 대기 후 홈으로 이동
+        // setTimeout(() => {
+        // }, 500); // 500ms 대기 후 홈으로 이동
 
         // 로그인 성공 후 홈으로 리다이렉트
         // window.location.href = '/home';
@@ -143,6 +143,7 @@ const OAuthVerification = () => {
       }
     } catch (error) {
       console.error(error);
+      // TODO: 에러 발생 시 어느 페이지로 이동 시킬 지 결정 후 구현.
     }
   };
 
@@ -159,24 +160,18 @@ const OAuthVerification = () => {
       />
     );
   }
-
-  // 이메일 인증이 필요한 경우 이메일 인증 폼을 렌더링
-  if (state.user && !state.user.data.ableToLogin) {
-    return (
-      <Layout isBackBtnExist pageName="이메일 인증">
-        {!emailSent ? (
-          <EmailVerification onSend={handleSendVerificationEmail} />
-        ) : (
-          <VerificationCodeInput
-            onVerify={handleVerifyCode}
-            onResend={handleSendVerificationEmail}
-          />
-        )}
-      </Layout>
-    );
-  }
-
-  return null;
+  return (
+    <Layout isBackBtnExist pageName="이메일 인증">
+      {!emailSent ? (
+        <EmailVerification onSend={handleSendVerificationEmail} />
+      ) : (
+        <VerificationCodeInput
+          onVerify={handleVerifyCode}
+          onResend={handleSendVerificationEmail}
+        />
+      )}
+    </Layout>
+  );
 };
 
 export default OAuthVerification;

--- a/src/pages/UserInfo.jsx
+++ b/src/pages/UserInfo.jsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { Container, Typography, Box, CircularProgress } from '@mui/material';
+import styled from 'styled-components';
+import AuthApi from '../services/auth.api';
+
+// Styled Component 정의
+const StyledContainer = styled(Container)`
+  max-width: 600px;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: #fff;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  padding: 20px;
+`;
+
+const UserInfo = () => {
+  const [userInfo, setUserInfo] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const response = await AuthApi.getMyInfo(); // AuthApi 메소드 호출
+        setUserInfo(response.data);
+      } catch (err) {
+        setError(err.response ? err.response.data : '오류 발생');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
+
+  return (
+    <StyledContainer>
+      <Typography variant="h4" align="center" color="#333" gutterBottom>
+        내 정보 조회
+      </Typography>
+      {loading && <CircularProgress />}
+      {error && (
+        <Typography color="red" align="center">
+          {error.message}
+        </Typography>
+      )}
+      {userInfo && (
+        <Box textAlign="center" mt={2}>
+          <Typography>
+            <strong>ID:</strong> {userInfo.id}
+          </Typography>
+          <Typography>
+            <strong>Email:</strong> {userInfo.email}
+          </Typography>
+          <Typography>
+            <strong>Nickname:</strong> {userInfo.nickname || 'N/A'}
+          </Typography>
+          <Typography>
+            <strong>Profile URL:</strong> {userInfo.profileUrl || 'N/A'}
+          </Typography>
+          <Typography>
+            <strong>Created At:</strong> {userInfo.createdAt}
+          </Typography>
+        </Box>
+      )}
+      {!loading && !error && !userInfo && (
+        <Typography>정보를 불러올 수 없습니다.</Typography>
+      )}
+    </StyledContainer>
+  );
+};
+
+export default UserInfo;

--- a/src/services/auth.api.js
+++ b/src/services/auth.api.js
@@ -15,6 +15,21 @@ const AuthApi = {
     apiClient.post('/auth/send-verification-code', data),
   // 인증 코드 확인 요청
   verifyCode: (data) => apiClient.post('/auth/verify-code', data),
+  // 액세스 토큰 재발급 요청 메서드
+  refreshAccessToken() {
+    return apiClient.post(
+      '/token/refresh',
+      {},
+      {
+        withCredentials: true, // 쿠키를 포함한 요청
+      }
+    );
+  },
+  // 내 정보 요청 메소드
+  getMyInfo: () =>
+    apiClient.get('/users/me', {
+      withCredentials: true, // 쿠키 포함 설정
+    }),
 };
 
 export default AuthApi; // AuthApi 객체를 기본 내보내기

--- a/src/utils/cookieUtil.js
+++ b/src/utils/cookieUtil.js
@@ -1,0 +1,15 @@
+import { Cookies } from 'react-cookie';
+
+const cookies = new Cookies();
+
+export const setCookie = (name, value, options) => {
+  return cookies.set(name, value, { ...options });
+};
+
+export const getCookie = (name) => {
+  return cookies.get(name);
+};
+
+export const removeCookie = (name) => {
+  return cookies.remove(name);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2150,6 +2150,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
+  integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
+
 "@types/eslint@^7.29.0 || ^8.4.1":
   version "8.56.12"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.56.12.tgz#1657c814ffeba4d2f84c0d4ba0f44ca7ea1ca53a"
@@ -2214,6 +2219,14 @@
   integrity sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==
   dependencies:
     "@types/node" "*"
+
+"@types/hoist-non-react-statics@^3.3.5":
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz#dab7867ef789d87e2b4b0003c9d65c49cc44a494"
+  integrity sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
 
 "@types/html-minifier-terser@^6.0.0":
   version "6.1.0"
@@ -3622,6 +3635,11 @@ cookie@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.1.tgz#2f73c42142d5d5cf71310a74fc4ae61670e5dbc9"
   integrity sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==
+
+cookie@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 core-js-compat@^3.38.0, core-js-compat@^3.38.1:
   version "3.38.1"
@@ -5395,7 +5413,7 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -8237,6 +8255,15 @@ react-calendar@^5.0.0:
     get-user-locale "^2.2.1"
     warning "^4.0.0"
 
+react-cookie@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/react-cookie/-/react-cookie-7.2.1.tgz#4a90603df57634bd7edaca325a3b9b584550680a"
+  integrity sha512-UcE6njAy5UmKzU9RywIvvtbHIQydhh6JP55yVbGwQ8Tp/wSPp2HOYVZdRI55zfbkW6zQv9SEs42mS3a9cIUQ0g==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.5"
+    hoist-non-react-statics "^3.3.2"
+    universal-cookie "^7.0.0"
+
 react-dev-utils@^12.0.1:
   version "12.0.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-12.0.1.tgz#ba92edb4a1f379bd46ccd6bcd4e7bc398df33e73"
@@ -9724,6 +9751,14 @@ unique-string@^2.0.0:
   integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
   dependencies:
     crypto-random-string "^2.0.0"
+
+universal-cookie@^7.0.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-7.2.1.tgz#dd8ad1c8b514c59c1b797f9dfdd384bdfff44282"
+  integrity sha512-GEKneQ0sz8qbobkYM5s9elAx6l7GQDNVl3Siqmc7bt/YccyyXWDPn+fht3J1qMcaLwPrzkty3i+dNfPGP2/9hA==
+  dependencies:
+    "@types/cookie" "^0.6.0"
+    cookie "^0.7.2"
 
 universalify@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
작업 내용 (What)
액세스 토큰 재발급 API 연동 
axios 인터셉터 설정
signUpOrLogin 메소드명 변경
내 정보 조회 API 연동 테스트 화면 구현

변경 사항 (Changes)
액세스 토큰 재발급 API 연동 
axios 응답 인터셉터 설정
- 요청 인터셉터에서 accessToken 쿠키 파싱해서 Authorization 헤더에 실어보내는 로직 구현
- 응답 인터셉터에서 403 에러 발생 시 액세스 토큰 재발급 후 이전 요청을 다시 보내는 로직 구현 
signUpOrLogin 메소드명 변경(confirmUserLogin 으로)
내 정보 조회 API 연동 테스트 화면 구현