### PR TITLE
fix:레시피목록 가격+몇인분 표기

### DIFF
--- a/src/pages/RecipePage.jsx
+++ b/src/pages/RecipePage.jsx
@@ -160,7 +160,7 @@ const RecipePage = () => {
               </RecipeImageBox>
             </a>
             <TitleText>{recipe.title}</TitleText>
-            <PriceText>{formatPrice(recipe.price)}원 ({recipe.servings}인분기준)</PriceText>
+            <PriceText>{formatPrice(recipe.price / recipe.servings)}원 (1인분기준)</PriceText>
             <StarText>
               {renderStars(recipe.avgRatings)} ({recipe.avgRatings}점)
             </StarText>

--- a/src/pages/RecipePage.jsx
+++ b/src/pages/RecipePage.jsx
@@ -3,10 +3,11 @@ import axios from 'axios';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
-import { Button } from '@mui/material';
 import Layout from '../components/layout/Layout';
 import { ORDER, SORT } from '../utils/sort';
 import { FilterDropdownButton } from '../components/common/Button/FilterDropdownButton';
+import { formatPrice } from '../utils/formatData';
+
 
 const RecipePage = () => {
   const navigate = useNavigate();
@@ -151,16 +152,15 @@ const RecipePage = () => {
 
           <List key={recipe.id}>
             <a href={`http://localhost:8080/api/recipes/${recipe.id}`}>
-              <RecipeImageBox>
-                {/* <img style={{width:'90%'}} alt={recipe.title} src={`http://localhost:8080/img/${recipe.thumbnailUrl?.split('\\').pop()}`}/> */}
+            <RecipeImageBox>
                 <RecipeImage
                   alt={recipe.title}
-                  src={`http://localhost:8080/img/${recipe.thumbnailUrl}.jpg`}
+                  src={`${import.meta.env.VITE_SERVER}${recipe.thumbnailUrl}`}
                 />
               </RecipeImageBox>
             </a>
             <TitleText>{recipe.title}</TitleText>
-            <PriceText>{recipe.price}원</PriceText>
+            <PriceText>{formatPrice(recipe.price)}원 ({recipe.servings}인분기준)</PriceText>
             <StarText>
               {renderStars(recipe.avgRatings)} ({recipe.avgRatings}점)
             </StarText>
@@ -260,7 +260,7 @@ const TitleText = styled.h3`
 
 // 가격
 const PriceText = styled.a`
-  font-size: 12px;
+  font-size: 11px;
   margin: 3px 0;
 `;
 

--- a/src/utils/formatData.jsx
+++ b/src/utils/formatData.jsx
@@ -1,0 +1,15 @@
+// 숫자 쉼표 표기 (1000 -> 1,000)
+export const formatPrice = (number) => {
+    return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+// 1천(k), 1백만(M) 표기
+export const formatFavoriteCount = (count) => {
+    if (count >= 1000000) {
+        return `${(count / 1000000).toFixed(1)}M` // 100만 이상 M표기 (소수점 1자리까지)
+    } else if (count >= 1000) {
+        return `${(count /1000).toFixed(1)}k` // 1000 이상 k표기 (소수점 1자리까지)
+    } else {
+        return count.toString();
+    }
+}


### PR DESCRIPTION
## 작업 내용
레시피 목록 페이지 가격 옆 인분 표기 : 3,333원 (1인분기준)

## 추가 내용
가격 입력 태그에 {recipe.servings}인분기준 추가

## 예시
![몇인분](https://github.com/user-attachments/assets/b02d7fa5-d832-45f3-b967-4a2bc0552482)
