### PR TITLE
Feat/weekly detail page

### DIFF
--- a/src/hooks/useWeeklyDate.js
+++ b/src/hooks/useWeeklyDate.js
@@ -67,6 +67,7 @@ export const useWeeklyDate = () => {
     currentMonth,
     weekNumber,
     firstSundayDateString,
+    currentDate,
     handleDecreaseWeek,
     handleIncreaseWeek,
     isCurrentWeek,

--- a/src/hooks/useWeeklyDate.js
+++ b/src/hooks/useWeeklyDate.js
@@ -15,7 +15,7 @@ export const useWeeklyDate = () => {
   const [firstSundayDateString, setFirstSundayDateString] = useState('');
   const [isCurrentWeek, setIsCurrentWeek] = useState(true); // 현재 주차 여부
 
-  // 현재 주차와 비교하여 상태 업데이트
+  // 현재 주차와 비교
   const updateCurrentWeek = (newDate) => {
     const current = getCurrentYearAndWeek(new Date());
     const { year: newYear, week: newWeek } = getCurrentYearAndWeek(newDate);

--- a/src/pages/BudgetPage.jsx
+++ b/src/pages/BudgetPage.jsx
@@ -48,6 +48,8 @@ const BudgetPage = () => {
       setRecipes(recipes);
       resetData();
       calculatePrices(recipes); // 함수에 recipes를 보냄
+      console.log('getUsedWeeklyBudget_year : ', year);
+      console.log('getUsedWeeklyBudget_week : ', week);
     } catch (error) {
       console.error('사용 예산 데이터 출력 중 오류 발생', error);
     }
@@ -124,14 +126,28 @@ const BudgetPage = () => {
     setAveragePrice(0);
     setHighestPriceTitle('');
     setLowestPriceTitle('');
+    console.log('year: ', year);
+    console.log('week: ', week);
+    console.log('weekNumber: ', weekNumber);
+    console.log('currentMonth: ', currentMonth);
   };
 
   // 달력 클릭 시 주차 상세 페이지 이동
   const handleCalendarClick = () => {
-    const confirmNavigation = window.confirm('주간 상세 페이지로 이동합니다.');
-    if (confirmNavigation) {
-      navigate('/weekly-details');
-    }
+    setIsModalOpen(true);
+  };
+  const handleModalClose = () => {
+    setIsModalOpen(false);
+  };
+  // 모달 확인 버튼 클릭 시 처리
+  const handleModalConfirm = () => {
+    setIsModalOpen(false);
+    navigate('/weekly-details', {
+      state: { year, weekNumber, week, currentMonth, isCurrentWeek },
+    });
+    console.log('state_year_ : ', year);
+    console.log('state_week_ : ', week);
+    console.log('state_weekNumber_ : ', weekNumber);
   };
 
   return (

--- a/src/pages/BudgetPage.jsx
+++ b/src/pages/BudgetPage.jsx
@@ -17,8 +17,6 @@ const BudgetPage = () => {
   const [budgetAmount, setBudgetAmount] = useState(0); // 설정한 예산
   const [useAmount, setUseAmount] = useState(0); // 사용한 예산
   const [remainingBudget, setRemainingBudget] = useState(0); // 남은 예산
-  const [currentDate, setCurrentDate] = useState(new Date());
-  const [firstSundayDateString, setFirstSundayDateString] = useState('');
   const [recipes, setRecipes] = useState([]);
   const [highestPrice, setHighestPrice] = useState(0); // 가장 비싼 레시피 가격
   const [lowestPrice, setLowestPrice] = useState(0); // 가장 저렴한 레시피 가격
@@ -33,6 +31,7 @@ const BudgetPage = () => {
   const {
     year,
     week,
+    currentDate,
     currentMonth,
     weekNumber,
     isCurrentWeek,
@@ -54,8 +53,6 @@ const BudgetPage = () => {
       setRecipes(recipes);
       resetData();
       calculatePrices(recipes); // 함수에 recipes를 보냄
-      console.log('getUsedWeeklyBudget_year : ', year);
-      console.log('getUsedWeeklyBudget_week : ', week);
     } catch (error) {
       console.error('사용 예산 데이터 출력 중 오류 발생', error);
     }
@@ -94,10 +91,6 @@ const BudgetPage = () => {
     setAveragePrice(0);
     setHighestPriceTitle('');
     setLowestPriceTitle('');
-    console.log('year: ', year);
-    console.log('week: ', week);
-    console.log('weekNumber: ', weekNumber);
-    console.log('currentMonth: ', currentMonth);
   };
 
   // 달력 클릭 시 컨펌 모달 > 주차 상세 페이지
@@ -113,9 +106,6 @@ const BudgetPage = () => {
     navigate('/weekly-details', {
       state: { year, weekNumber, week, currentMonth, isCurrentWeek },
     });
-    console.log('state_year_ : ', year);
-    console.log('state_week_ : ', week);
-    console.log('state_weekNumber_ : ', weekNumber);
   };
 
   return (
@@ -185,7 +175,7 @@ const BudgetPage = () => {
         </BudgetSettingContainer>
       </BudgetContainer>
       <CalendarContainer onClick={handleCalendarClick}>
-        <WeeklyCalendar currentDate={currentDate}>달력</WeeklyCalendar>
+        <WeeklyCalendar currentDate={currentDate} />
       </CalendarContainer>
 
       {/* 달력 클릭 모달 */}

--- a/src/pages/WeeklyDetail.jsx
+++ b/src/pages/WeeklyDetail.jsx
@@ -3,12 +3,9 @@ import Layout from '../components/layout/Layout';
 import { budgetAPI } from '../services/budget.api';
 import { useAuth } from '../context/Auth/AuthContext';
 import styled from 'styled-components';
-import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
-import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { BudgetRecipeSlide } from '../components/display/BudgetRecipeSlide';
 import { recommendAPI } from '../services/recommend.api';
-import { useWeeklyDate } from '../hooks/useWeeklyDate';
 
 // 날짜 계산 (헤더에 날짜 표시)
 const WeeklyDetail = () => {
@@ -63,46 +60,46 @@ const WeeklyDetail = () => {
       <DateContainer>
         <SplitData>
           <h2 style={{ fontFamily: 'yg-jalnan' }}>
-            {currentMonth} {weekNumber}주차
+            {year}년 {currentMonth} {weekNumber}주차
           </h2>
         </SplitData>
       </DateContainer>
       <RecipeListBox>
+        <RecipeListText>추천받은 레시피</RecipeListText>
         {recommendedRecipes.length > 0 ? (
           <>
-            <RecipeListText>추천받은 레시피</RecipeListText>
             <div style={{ overflow: 'hidden' }}>
               <BudgetRecipeSlide recipes={recommendedRecipes} />
             </div>
           </>
         ) : (
           <>
-            <RecipeListText>추천받은 레시피가 없습니다.</RecipeListText>
+            <EmptyBox></EmptyBox>
+            <NoRecipeListText>추천받은 레시피가 없습니다.</NoRecipeListText>
+            <EmptyBox></EmptyBox>
           </>
         )}
       </RecipeListBox>
-      <br />
-      <br />
-      <br />
+
       <RecipeListBox>
+        <RecipeListText>요리한 레시피</RecipeListText>
         {usedRecipes.length > 0 ? (
           <>
-            <RecipeListText>요리한 레시피</RecipeListText>
             <div style={{ overflow: 'hidden' }}>
               <BudgetRecipeSlide recipes={usedRecipes} />
             </div>
           </>
         ) : (
           <>
-            <RecipeListText>요리한 레시피가 없습니다.</RecipeListText>
-            <br />
-            <br />
+            <EmptyBox></EmptyBox>
+            <NoRecipeListText>요리한 레시피가 없습니다.</NoRecipeListText>
+            <EmptyBox></EmptyBox>
             {isCurrentWeek && ( // 현재 주차에서만 표시
               <LinkButtonWrapper>
                 <LinkButton onClick={() => navigate('/home')}>
-                  <p style={{ margin: '5px' }}>
+                  <UseRecipeLinkText>
                     아직 요리한 레시피가 없네요! 요리하러 갈까요?
-                  </p>
+                  </UseRecipeLinkText>
                 </LinkButton>
               </LinkButtonWrapper>
             )}
@@ -132,12 +129,6 @@ const SplitData = styled.div`
   justify-content: center;
 `;
 
-const ArrowButton = styled.div`
-  cursor: pointer;
-  color: ${({ isCurrentWeek }) =>
-    isCurrentWeek ? '#b0b0b0' : 'initial'}; // 회색으로 변경
-`;
-
 const RecipeListBox = styled.div`
   width: 95%;
   margin-bottom: 10px;
@@ -147,6 +138,16 @@ const RecipeListText = styled.div`
   font-family: 'yg-jalnan';
   font-size: 18px;
   margin-bottom: 10px;
+`;
+
+const NoRecipeListText = styled.div`
+  font-size: 30px;
+  text-align: center;
+  color: #888888;
+  font-family: 'GangwonEduPowerExtraBoldA';
+`;
+const EmptyBox = styled.div`
+  height: 93px;
 `;
 
 const LinkButtonWrapper = styled.div`
@@ -173,4 +174,12 @@ const LinkButton = styled.button`
     background-color: #ffd700; // hover 시 진한 노란색
     color: white;
   }
+`;
+
+const UseRecipeLinkText = styled.p`
+  margin: 5px;
+  padding-top: 10px;
+  line-height: 1.5;
+  text-shadow: 1px 1px 0px #888888, /* 위쪽 */ -1px -1px 0px #888888,
+    /* 왼쪽 아래 */ 1px -1px 0px #888888, /* 오른쪽 아래 */ -1px 1px 0px #888888; /* 왼쪽 위 */
 `;

--- a/src/pages/WeeklyDetail.jsx
+++ b/src/pages/WeeklyDetail.jsx
@@ -5,11 +5,10 @@ import { useAuth } from '../context/Auth/AuthContext';
 import styled from 'styled-components';
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { BudgetRecipeSlide } from '../components/display/BudgetRecipeSlide';
 import { recommendAPI } from '../services/recommend.api';
 import { useWeeklyDate } from '../hooks/useWeeklyDate';
-import { toast } from 'react-toastify';
 
 // 날짜 계산 (헤더에 날짜 표시)
 const WeeklyDetail = () => {
@@ -17,14 +16,17 @@ const WeeklyDetail = () => {
   const { state } = useAuth();
   const [usedRecipes, setUsedRecipes] = useState([]); // 사용 레시피
   const [recommendedRecipes, setRecommendedRecipes] = useState([]); // 추천받은 레시피
+  const location = useLocation();
+  const { year, week, weekNumber, currentMonth, isCurrentWeek } =
+    location.state || {};
 
   // 날짜 관리 훅 가져오기
   const {
-    year,
-    week,
-    currentMonth,
-    weekNumber,
-    isCurrentWeek,
+    // year,
+    // weekNumber,
+    // week,
+    // currentMonth,
+    // isCurrentWeek,
     handleDecreaseWeek,
     handleIncreaseWeek,
   } = useWeeklyDate();
@@ -57,15 +59,11 @@ const WeeklyDetail = () => {
   useEffect(() => {
     getUsedRecipes();
     getRecommendedRecipes();
+    console.log('year: ', year);
+    console.log('week: ', week);
+    console.log('weekNumber: ', weekNumber);
+    console.log('currentMonth: ', currentMonth);
   }, [year, week]);
-
-  // 레시피 미사용시, 홈으로 보내는 버튼 클릭 시 toast 출력
-  const handleLinkCilck = () => {
-    navigate('/home');
-    toast.info('추천받은 레시피를 선택하여\n 요리해보세요!', {
-      className: 'custom-toast',
-    });
-  };
 
   return (
     <Layout
@@ -94,41 +92,41 @@ const WeeklyDetail = () => {
         </SplitData>
       </DateContainer>
       <RecipeListBox>
-        <RecipeListText>추천받은 레시피</RecipeListText>
         {recommendedRecipes.length > 0 ? (
           <>
+            <RecipeListText>추천받은 레시피</RecipeListText>
             <div style={{ overflow: 'hidden' }}>
               <BudgetRecipeSlide recipes={recommendedRecipes} />
             </div>
           </>
         ) : (
           <>
-            <EmptyBox></EmptyBox>
-            <NoRecipeListText>추천받은 레시피가 없습니다.</NoRecipeListText>
-            <EmptyBox></EmptyBox>
+            <RecipeListText>추천받은 레시피가 없습니다.</RecipeListText>
           </>
         )}
       </RecipeListBox>
+      <br />
+      <br />
+      <br />
       <RecipeListBox>
-        <RecipeListText>요리한 레시피</RecipeListText>
         {usedRecipes.length > 0 ? (
           <>
+            <RecipeListText>요리한 레시피</RecipeListText>
             <div style={{ overflow: 'hidden' }}>
               <BudgetRecipeSlide recipes={usedRecipes} />
             </div>
           </>
         ) : (
           <>
-            <EmptyBox></EmptyBox>
-            <NoRecipeListText>요리한 레시피가 없습니다.</NoRecipeListText>
-            <EmptyBox></EmptyBox>
-
+            <RecipeListText>요리한 레시피가 없습니다.</RecipeListText>
+            <br />
+            <br />
             {isCurrentWeek && ( // 현재 주차에서만 표시
               <LinkButtonWrapper>
-                <LinkButton onClick={handleLinkCilck}>
-                  <UseRecipeLinkText>
-                    아직 요리한 레시피가 없네요! <br /> 요리하러 가볼까요?
-                  </UseRecipeLinkText>
+                <LinkButton onClick={() => navigate('/home')}>
+                  <p style={{ margin: '5px' }}>
+                    아직 요리한 레시피가 없네요! 요리하러 갈까요?
+                  </p>
                 </LinkButton>
               </LinkButtonWrapper>
             )}
@@ -160,7 +158,8 @@ const SplitData = styled.div`
 
 const ArrowButton = styled.div`
   cursor: pointer;
-  color: ${({ isCurrentWeek }) => (isCurrentWeek ? '#b0b0b0' : 'initial')};
+  color: ${({ isCurrentWeek }) =>
+    isCurrentWeek ? '#b0b0b0' : 'initial'}; // 회색으로 변경
 `;
 
 const RecipeListBox = styled.div`
@@ -168,21 +167,10 @@ const RecipeListBox = styled.div`
   margin-bottom: 10px;
   text-align: left;
 `;
-
 const RecipeListText = styled.div`
   font-family: 'yg-jalnan';
   font-size: 18px;
   margin-bottom: 10px;
-`;
-
-const NoRecipeListText = styled.div`
-  font-size: 30px;
-  text-align: center;
-  color: #888888;
-  font-family: 'GangwonEduPowerExtraBoldA';
-`;
-const EmptyBox = styled.div`
-  height: 93px;
 `;
 
 const LinkButtonWrapper = styled.div`
@@ -192,22 +180,21 @@ const LinkButtonWrapper = styled.div`
 `;
 
 const LinkButton = styled.button`
-  width: 90%;
+  width: 100%;
+  height: 30px;
+  display: block;
+  background-color: #e0e0e0;
   text-align: center;
   border: 0px solid white;
-  border-radius: 20px;
-  font-size: 32px;
-  padding: 10px;
+  border-radius: 10px;
+  font-size: 20px;
+  padding: 3px;
   font-family: 'GangwonEduPowerExtraBoldA';
+  color: orange;
   overflow: hidden;
-  background-color: #fef2b0;
-  color: white;
-`;
-
-const UseRecipeLinkText = styled.p`
-  margin: 5px;
-  padding-top: 10px;
-  line-height: 1.5;
-  text-shadow: 1px 1px 0px #888888, /* 위쪽 */ -1px -1px 0px #888888,
-    /* 왼쪽 아래 */ 1px -1px 0px #888888, /* 오른쪽 아래 */ -1px 1px 0px #888888; /* 왼쪽 위 */
+  transition: background-color 0.3s;
+  &:hover {
+    background-color: #ffd700; // hover 시 진한 노란색
+    color: white;
+  }
 `;

--- a/src/pages/WeeklyDetail.jsx
+++ b/src/pages/WeeklyDetail.jsx
@@ -20,17 +20,6 @@ const WeeklyDetail = () => {
   const { year, week, weekNumber, currentMonth, isCurrentWeek } =
     location.state || {};
 
-  // 날짜 관리 훅 가져오기
-  const {
-    // year,
-    // weekNumber,
-    // week,
-    // currentMonth,
-    // isCurrentWeek,
-    handleDecreaseWeek,
-    handleIncreaseWeek,
-  } = useWeeklyDate();
-
   // 추천받은 레시피 정보 가져오기(is_used 무관)
   const getRecommendedRecipes = async () => {
     try {
@@ -59,10 +48,6 @@ const WeeklyDetail = () => {
   useEffect(() => {
     getUsedRecipes();
     getRecommendedRecipes();
-    console.log('year: ', year);
-    console.log('week: ', week);
-    console.log('weekNumber: ', weekNumber);
-    console.log('currentMonth: ', currentMonth);
   }, [year, week]);
 
   return (
@@ -77,18 +62,9 @@ const WeeklyDetail = () => {
     >
       <DateContainer>
         <SplitData>
-          <ArrowButton onClick={handleDecreaseWeek}>
-            <KeyboardArrowLeftIcon fontSize="large" />
-          </ArrowButton>
           <h2 style={{ fontFamily: 'yg-jalnan' }}>
             {currentMonth} {weekNumber}주차
           </h2>
-          <ArrowButton
-            onClick={handleIncreaseWeek}
-            isCurrentWeek={isCurrentWeek}
-          >
-            <KeyboardArrowRightIcon fontSize="large" />
-          </ArrowButton>
         </SplitData>
       </DateContainer>
       <RecipeListBox>


### PR DESCRIPTION
## 작업 내용
- 주간 상세 페이지 스타일링
- 주차 변경시, 달력 UI가 변하지 않는 오류 수정
- 예산 관리 페이지에서 주차 변경 후, 해당 주차 상세 페이지로 바로 이동하는 기능 구현
- main 병합 시, 적용되지 않던 스타일링 추가

## 예시
![주간 상세 페이지 이동](https://github.com/user-attachments/assets/c02750c2-5746-46eb-a9d6-39ea5bbb68cf)

![주간 상세 페이지 최종](https://github.com/user-attachments/assets/0770782c-1764-4e75-ac5f-0cb5cb305482)
